### PR TITLE
feat: passthrough as default auth mode

### DIFF
--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -223,7 +223,7 @@ export const config = {
       return env.string('TEST_SAMPLES_DIR', 'test-samples')
     },
     get enableClientAuth() {
-      return env.bool('ENABLE_CLIENT_AUTH', true)
+      return env.bool('ENABLE_CLIENT_AUTH', false)
     },
   },
 


### PR DESCRIPTION
This pull request introduces a new passthrough authentication mode for the proxy service, allowing requests with a Bearer token to bypass client authentication when the feature is disabled. Additionally, the default configuration for client authentication has been updated to be disabled by default.

**Authentication changes:**

* Added passthrough authentication logic in `ProxyService` to allow Bearer token requests to bypass client authentication when `enableClientAuth` is set to `false`. This sets up the appropriate headers and logs the passthrough event.

**Configuration changes:**

* Changed the default value of `enableClientAuth` in `config/index.ts` from `true` to `false`, disabling client authentication by default.
* Imported `config` into `ProxyService.ts` to access the new configuration flag for authentication logic.